### PR TITLE
Upgrade transitive dependencies to close security vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,9 +9,6 @@
     "shared",
     "typescript"
   ],
-  "engines": {
-    "node": ">=14.17.0"
-  },
   "homepage": "https://github.com/skypilot-dev/eslint-config-typescript#readme",
   "bugs": {
     "url": "https://github.com/skypilot-dev/eslint-config-typescript/issues"
@@ -31,10 +28,10 @@
     "/lib"
   ],
   "scripts": {
+    "build": "rm -rf lib && mkdir -p lib && cp src/index.js lib/",
     "check-ci": "yarn run check-code && yarn run build",
     "check-code": "yarn run check-types && yarn run lint --quiet && yarn test",
     "check-types": "tsc",
-    "build": "rm -rf lib && mkdir -p lib && cp src/index.js lib/",
     "compile-ts": "babel ./src --out-dir ./lib --extensions .ts --ignore '**/__tests__/*' --ignore '**/*.d.ts' && yarn run generate-typings",
     "generate-typings": "tsc --project tsconfig.generate-typings.json",
     "lint": "eslint --cache '**/*.{js,ts}'",
@@ -44,6 +41,7 @@
     "test:all": "jest --config jest.config.js",
     "test:int": "jest --config jest.integration.config.js"
   },
+  "dependencies": {},
   "devDependencies": {
     "@skypilot/toolchain": "^5.2.4-next.6",
     "@typescript-eslint/eslint-plugin": "^5.21.0",
@@ -62,6 +60,9 @@
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-jest": "^26.1.5",
     "typescript": "^4.6.4"
+  },
+  "engines": {
+    "node": ">=14.17.0"
   },
   "publishConfig": {
     "access": "restricted"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2525,9 +2525,9 @@ camelcase@^6.0.0:
   integrity sha512-8KMDF1Vz2gzOq54ONPJS65IvTUaB1cHJ2DMM7MbPmLZljDH1qpzzLsWdiN9pHh6qvkRVDTi/07+eNGch/oLU4w==
 
 caniuse-lite@^1.0.30001219:
-  version "1.0.30001239"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001239.tgz#66e8669985bb2cb84ccb10f68c25ce6dd3e4d2b8"
-  integrity sha512-cyBkXJDMeI4wthy8xJ2FvDU6+0dtcZSJW3voUF8+e9f1bBeuvyZfc3PNbkOETyhbR+dGCPzn9E7MA3iwzusOhQ==
+  version "1.0.30001334"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001334.tgz"
+  integrity sha512-kbaCEBRRVSoeNs74sCuq92MJyGrMtjWVfhltoHUCW4t4pXFvGjUBrfo47weBRViHkiV3eBYyIsfl956NtHGazw==
 
 capture-exit@^2.0.0:
   version "2.0.0"
@@ -5360,12 +5360,7 @@ minimatch@^3.1.2:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@^1.1.1, minimist@^1.2.0, minimist@^1.2.5:
-  version "1.2.5"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
-  integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
-
-minimist@^1.2.6:
+minimist@^1.1.1, minimist@^1.2.0, minimist@^1.2.5, minimist@^1.2.6:
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
   integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==


### PR DESCRIPTION
Upgraded `minimist` and `caniuse-lite`.